### PR TITLE
Set UTC timezone for date conversion in PDF creator

### DIFF
--- a/src/main/java/com/temenos/t24/ksa/pdf/PDFcreator.java
+++ b/src/main/java/com/temenos/t24/ksa/pdf/PDFcreator.java
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import com.itextpdf.kernel.font.PdfFont;
 import com.itextpdf.io.font.PdfEncodings;
@@ -155,7 +156,9 @@ public class PDFcreator {
     // Convert "dd MMM yyyy HH:mm:ss" to "yyyy-MM-ddTHH:mm:ssZ"
     private static String convertDateTimeToIso(String invoiceDateTime) {
         SimpleDateFormat inputFormat = new SimpleDateFormat("dd MMM yyyy HH:mm:ss");
+        inputFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         SimpleDateFormat outputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        outputFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         try {
             Date date = inputFormat.parse(invoiceDateTime);
             return outputFormat.format(date);


### PR DESCRIPTION
## Summary
- ensure both input and output date formats use UTC timezone when converting invoice timestamps

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bae9f4eebc832995f26c2bf343c3be